### PR TITLE
edits for shifter/denali

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,3 @@ RUN echo 'Sys.setenv(GLM_PATH = "/usr/local/bin/GLM/glm")' >> /usr/local/lib/R/e
 #RUN install2.r --error \
 #  httr \
 #  package...
-
-WORKDIR /usr/local/bin
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ RUN apt-get --assume-yes install libgd-dev m4 libnetcdf-dev
 
 #build GLM executable from source, based on jread's build script
 #libaed, libutil, and libaid-water could be built from a fixed commit like libplot is
-RUN mkdir /work && \
-  chown rstudio /work && \
-  cd /work && \
+# mkdir /usr/local/bin && \
+#  chown rstudio /usr/local/bin && \
+RUN cd /usr/local/bin && \
   git clone https://github.com/AquaticEcoDynamics/libplot.git && \
   cd libplot && git reset --hard 727ed89ce21d84abadf65e16854e8dd307d0c191 && cd .. && \
   git clone https://github.com/AquaticEcoDynamics/libaed2.git && \
@@ -22,12 +22,12 @@ RUN mkdir /work && \
 RUN Rscript -e 'remotes::install_github("jsta/GLM3r")'
 
 #set GLM_PATH variable so GLM3r uses the executable built here instead of the one included with the pacakage
-RUN echo 'Sys.setenv(GLM_PATH = "/work/GLM/glm")' >> /usr/local/lib/R/etc/Rprofile.site
+RUN echo 'Sys.setenv(GLM_PATH = "/usr/local/bin/GLM/glm")' >> /usr/local/lib/R/etc/Rprofile.site
 
 #add additional R packages to install here:
 #RUN install2.r --error \
 #  httr \
 #  package...
 
-WORKDIR /work
+WORKDIR /usr/local/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ RUN apt-get --assume-yes install libgd-dev m4 libnetcdf-dev
 
 #build GLM executable from source, based on jread's build script
 #libaed, libutil, and libaid-water could be built from a fixed commit like libplot is
-# mkdir /usr/local/bin && \
-#  chown rstudio /usr/local/bin && \
 RUN cd /usr/local/bin && \
   git clone https://github.com/AquaticEcoDynamics/libplot.git && \
   cd libplot && git reset --hard 727ed89ce21d84abadf65e16854e8dd307d0c191 && cd .. && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM rocker/geospatial:4.0.3
 
-WORKDIR /home/rstudio/ 
 RUN apt-get update && apt-get install --assume-yes apt-utils
-RUN apt-get --assume-yes install libgd-dev m4 libnetcdf-dev 
+RUN apt-get --assume-yes install libgd-dev m4 libnetcdf-dev
 
 #build GLM executable from source, based on jread's build script
 #libaed, libutil, and libaid-water could be built from a fixed commit like libplot is
-RUN mkdir AquaticEcoDynamics && \
-  cd AquaticEcoDynamics && \
+RUN mkdir /work && \
+  chown rstudio /work && \
+  cd /work && \
   git clone https://github.com/AquaticEcoDynamics/libplot.git && \
-  cd libplot && git reset --hard 727ed89ce21d84abadf65e16854e8dd307d0c191 && cd .. && \ 
+  cd libplot && git reset --hard 727ed89ce21d84abadf65e16854e8dd307d0c191 && cd .. && \
   git clone https://github.com/AquaticEcoDynamics/libaed2.git && \
   git clone https://github.com/AquaticEcoDynamics/libutil.git && \
   git clone -b v3.1.0 https://github.com/AquaticEcoDynamics/GLM.git && \
@@ -17,19 +17,17 @@ RUN mkdir AquaticEcoDynamics && \
   cd GLM && ./build_glm.sh
 
 #this fork has fix for GLM_PATH variable when using
-#a different binary than included with the package; restore to 
+#a different binary than included with the package; restore to
 #GLEON repo when https://github.com/GLEON/GLM3r/pull/20 is merged
 RUN Rscript -e 'remotes::install_github("jsta/GLM3r")'
 
 #set GLM_PATH variable so GLM3r uses the executable built here instead of the one included with the pacakage
-RUN echo 'Sys.setenv(GLM_PATH = "/home/rstudio/AquaticEcoDynamics/GLM/glm")' >> /usr/local/lib/R/etc/Rprofile.site
+RUN echo 'Sys.setenv(GLM_PATH = "/work/GLM/glm")' >> /usr/local/lib/R/etc/Rprofile.site
 
 #add additional R packages to install here:
 #RUN install2.r --error \
 #  httr \
-#  package... 
+#  package...
 
-RUN mkdir -p glm3_test && \
-    chown rstudio glm3_test 
-WORKDIR glm3_test
+WORKDIR /work
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,7 @@ services:
       context: .
     ports:
       - "8787:8787"
-    volumes:
-      - data:/work/glm3_test
     environment:
       - ROOT=TRUE
       - PASSWORD=mypass
-
-volumes:
-  data:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
-version: "3.1" 
+version: "3.1"
 services:
   glm_test:
-    image: wdwatkins/glm3r:v0.3
+    image: aapplingusgs/glm3r:v0.4
     build:
       context: .
     ports:
       - "8787:8787"
     volumes:
-      - data:/home/rstudio/glm3_test                                                                                              
+      - data:/work/glm3_test
     environment:
       - ROOT=TRUE
       - PASSWORD=mypass


### PR DESCRIPTION
Got GLM3 running on Denali! I had to change where GLM was installed on the image, because it seems that Shifter hybridizes the file system visible on the container such that /home/rstudio no longer existed (instead, USGS user accounts like /home/aappling are visible). I didn't know where to put it that was (1) conventional, because I'm not very clear on linux+container file organization conventions, and (2) likely to work, because I don't know what logic is used to hybridize the file system on container launch. So I made a new folder `/work` - this does succeed, but I'm open to suggestions on a more standard place to install GLM.

The other change I had to make doesn't show up in this PR/repo, but I'll mention it here for completeness's sake: I have miniconda3 installed in my home directory on Denali/Caldera, and I learned that I had to run `conda deactivate` before using this container (specifically, somewhere between getting a job allocation and running `shifter`) if I wanted to access the version of R and R libraries offered by the GLM container. I'm taking notes on this part of the process at https://github.com/aappling-usgs/res-temperature-process-models/blob/main/README.md as I learn more.

I must have different default whitespace settings, because a lot of the changes in this PR are just whitespace edits that I did not make manually. I recommend the Ignore Whitespace option when reviewing this PR to see the actually very small number of changes I made.